### PR TITLE
Improve

### DIFF
--- a/lib/zip-a-folder.js
+++ b/lib/zip-a-folder.js
@@ -19,11 +19,11 @@ class ZipAFolder {
         // folder double check
         fs.access(srcFolder, fs.constants.F_OK, (notExistingError) => {
             if (notExistingError) {
-                callback(notExistingError);
+                return callback(notExistingError);
             }
             fs.access(path.dirname(zipFilePath), fs.constants.F_OK, (notExistingError) => {
                 if (notExistingError) {
-                    callback(notExistingError);
+                    return callback(notExistingError);
                 }
                 var output = fs.createWriteStream(zipFilePath);
                 var zipArchive = archiver('zip');

--- a/lib/zip-a-folder.js
+++ b/lib/zip-a-folder.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var archiver = require('archiver');
+var path = require('path');
 
 class ZipAFolder {
     static async zip(srcFolder, zipFilePath) {
@@ -15,20 +16,26 @@ class ZipAFolder {
     }
 
     static zipFolder(srcFolder, zipFilePath, callback) {
+        // folder double check
         fs.access(srcFolder, fs.constants.F_OK, (notExistingError) => {
             if (notExistingError) {
                 callback(notExistingError);
             }
-            var output = fs.createWriteStream(zipFilePath);
-            var zipArchive = archiver('zip');
+            fs.access(path.dirname(zipFilePath), fs.constants.F_OK, (notExistingError) => {
+                if (notExistingError) {
+                    callback(notExistingError);
+                }
+                var output = fs.createWriteStream(zipFilePath);
+                var zipArchive = archiver('zip');
 
-            output.on('close', function() {
-                callback();
+                output.on('close', function() {
+                    callback();
+                });
+
+                zipArchive.pipe(output);
+                zipArchive.directory(srcFolder, false);
+                zipArchive.finalize();
             });
-
-            zipArchive.pipe(output);
-            zipArchive.directory(srcFolder, false);
-            zipArchive.finalize();
         });
     }
 }


### PR DESCRIPTION
I found some error that my node server crashed when there is no parent directory of zipFilePath. So, I checked it. And we need to stop processing when meet error, so add return before callback().

Check please !