### PR TITLE
add a typescript .d.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.7",
   "description": "Forked the idea of @sole to zip a complete folder into a zip file but now using promises",
   "main": "lib/zip-a-folder.js",
+  "typings": "zip-a-folder.d.ts",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/zip-a-folder.d.ts
+++ b/zip-a-folder.d.ts
@@ -1,0 +1,4 @@
+declare module 'zip-a-folder' {
+  export function zip(srcFolder: string, zipFilePath: string): Promise<void | Error>;
+  export function zipFolder(srcFolder: string, zipFilePath: string, callback: (undefined | Error)): void;
+}


### PR DESCRIPTION
Fixes #4 

In my app I added this `declare module ...` section to a `3rd-party-types.d.ts` we have.

It worked pre' good, here it is showing the type def of `zip`, as well as it has `zipFolder` too:

<img width="441" alt=" 2019-04-26 at 10 59 17 AM" src="https://user-images.githubusercontent.com/28356/56821275-777f2780-6813-11e9-947f-0b4d5874d72f.png">

Haven't published a .d.ts file like this before though, think I just need to add the reference in package.json like I did.  Maybe @tyteen4a03 could try it out.