### PR TITLE
Fix type definition for callback

### DIFF
--- a/zip-a-folder.d.ts
+++ b/zip-a-folder.d.ts
@@ -1,4 +1,4 @@
 declare module 'zip-a-folder' {
   export function zip(srcFolder: string, zipFilePath: string): Promise<void | Error>;
-  export function zipFolder(srcFolder: string, zipFilePath: string, callback: (undefined | Error)): void;
+  export function zipFolder(srcFolder: string, zipFilePath: string, callback: (error?: Error) => void) : void;
 }


### PR DESCRIPTION
On executing `zipFolder` callback was defined as if it was expecting to get `Error` or `undefined` and Typescript is complaining when passing a proper callback as documented in README.md.

In this commit, I have fixed the type to be the right type expected for a callback that eventually can recive an error.