### PR TITLE
Add "types" entry to package.json’s exports for use from a type: "module" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@typings"
   ],
   "exports": {
+    "types": "./@typings/ZipAFolder.d.ts",
     "import": "./dist/lib/mjs/ZipAFolder.js",
     "require": "./dist/lib/cjs/ZipAFolder.js"
   },


### PR DESCRIPTION
fixes #52