### PR TITLE
fix: restore POSIX file permissions (chmod) in ZIP archives

### DIFF
--- a/lib/ZipAFolder.ts
+++ b/lib/ZipAFolder.ts
@@ -132,12 +132,12 @@ export class ZipAFolder {
 
         // Directories first (for directory-based use).
         for (const e of entries.filter((x) => x.isDirectory)) {
-            zipper.addDirectoryEntry(e.relativePath, e.stat.mtime);
+            zipper.addDirectoryEntry(e.relativePath, e.stat.mtime, e.stat.mode);
         }
 
         // Files.
         for (const e of entries.filter((x) => !x.isDirectory)) {
-            await zipper.addFileFromFs(e.fsPath, e.relativePath, e.stat.mtime);
+            await zipper.addFileFromFs(e.fsPath, e.relativePath, e.stat.mtime, e.stat.mode);
         }
 
         if (!customWS && hasTargetPath) {


### PR DESCRIPTION
Hi!

We ran into a regression after upgrading to v4 where files lose their attributes (specifically the executable bit) inside the generated archive. This causes issues when packaging for Linux/Debian environments, where these permissions are critical.

It seems the issue stems from the new `NativeZip` implementation defaulting to MS-DOS compatibility attributes, which effectively ignores the source file's mode.

I’ve updated the logic to correctly preserve POSIX permissions:
1.  The `fs.stat().mode` is now passed down from the collector to the `ZipEntry`.
2.  In the Central Directory Header, I'm now setting the **Version Made By** field to Unix (ID 3).
3.  The file mode is now correctly mapped to the upper 16 bits of the **External File Attributes** field.

This restores parity with version 3 behavior and adheres to the standard ZIP spec for Unix systems.

Thanks for the nice library!